### PR TITLE
docs: add implementation roadmap

### DIFF
--- a/docs/implementation-roadmap.md
+++ b/docs/implementation-roadmap.md
@@ -1,0 +1,47 @@
+# Implementation Roadmap
+
+This roadmap outlines the steps for evolving the "CodeX New Generation" platform from documentation into a fully functional environment covering the entire software lifecycle.
+
+## 1. Repository Structure & Tooling
+- Establish monorepo layout for frontend, backend, and shared modules.
+- Configure package managers (npm/pnpm for frontend, Python tooling for backend).
+- Set up linting, formatting, and commit hooks.
+- Introduce CI pipeline to run tests and static analysis on every pull request.
+
+## 2. Design System & UX
+- Expand the design system with reusable components and style guidelines.
+- Build Figma component library mirroring the implementation.
+- Document accessibility requirements and theming strategy.
+
+## 3. Frontend Application
+- Scaffold a React-based web app consuming the design system.
+- Integrate authentication flows and basic navigation.
+- Implement core user flows for "Plan", "Build", and "Test" stages.
+
+## 4. Backend Services
+- Initialize Python FastAPI service for REST APIs.
+- Define database schema and migrations.
+- Implement endpoints for project management and user accounts.
+- Add unit tests and integration tests.
+
+## 5. AI & Automation Features
+- Integrate OpenAI APIs for code generation and review.
+- Build task automation framework for test execution and deployment.
+- Expose AI-assisted features through both backend APIs and frontend UI.
+
+## 6. Deployment & Operations
+- Containerize services with Docker and define orchestration with Kubernetes.
+- Set up staging and production environments.
+- Implement logging, monitoring, and alerting.
+
+## 7. Documentation & Developer Experience
+- Maintain updated docs on setup, contribution guidelines, and architecture.
+- Provide code examples and tutorial videos.
+- Establish community support channels.
+
+## 8. Release Management
+- Adopt semantic versioning and changelog generation.
+- Automate release pipelines with CI/CD.
+- Gather user feedback and iterate regularly.
+
+This document will evolve as the project grows and tasks are completed.


### PR DESCRIPTION
## Summary
- add implementation roadmap outlining repository expansion, frontend, backend, AI, and ops milestones

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a0b93b8248332850f9f32b2a334ab