### PR TITLE
docs: expand implementation roadmap

### DIFF
--- a/docs/implementation-roadmap.md
+++ b/docs/implementation-roadmap.md
@@ -1,0 +1,64 @@
+# Implementation Roadmap
+
+This roadmap outlines the steps for evolving the "CodeX New Generation" platform from documentation into a fully functional environment covering the entire software lifecycle.
+
+## 1. Repository Structure & Tooling
+
+### Monorepo Layout
+1. Create `apps/frontend` for the web interface and `apps/backend` for API services.
+2. Add `packages/shared` for utilities and types consumed by both layers.
+3. Use a single root `README` and `LICENSE` to govern all modules.
+
+### Package Management
+1. Configure a root `package.json` and `pnpm-workspace.yaml` to manage frontend packages with `pnpm`.
+2. Introduce `pyproject.toml` using Poetry or PDM to handle backend dependencies.
+3. Document commands for installing dependencies in each workspace.
+
+### Linting, Formatting, and Commit Hooks
+1. Add ESLint and Prettier for JavaScript/TypeScript code.
+2. Add Black and Ruff (or Flake8) for Python formatting and linting.
+3. Create a `.editorconfig` to enforce consistent editor settings.
+4. Wire up Husky or `pre-commit` hooks so linting and formatting run before commits.
+
+### Continuous Integration
+1. Set up a GitHub Actions workflow that runs `pnpm lint`, `pnpm test`, and `pytest`.
+2. Include static type checks like `tsc` for TypeScript and `mypy` for Python.
+3. Require the workflow to pass on every pull request before merging.
+
+## 2. Design System & UX
+- Expand the design system with reusable components and style guidelines.
+- Build Figma component library mirroring the implementation.
+- Document accessibility requirements and theming strategy.
+
+## 3. Frontend Application
+- Scaffold a React-based web app consuming the design system.
+- Integrate authentication flows and basic navigation.
+- Implement core user flows for "Plan", "Build", and "Test" stages.
+
+## 4. Backend Services
+- Initialize Python FastAPI service for REST APIs.
+- Define database schema and migrations.
+- Implement endpoints for project management and user accounts.
+- Add unit tests and integration tests.
+
+## 5. AI & Automation Features
+- Integrate OpenAI APIs for code generation and review.
+- Build task automation framework for test execution and deployment.
+- Expose AI-assisted features through both backend APIs and frontend UI.
+
+## 6. Deployment & Operations
+- Containerize services with Docker and define orchestration with Kubernetes.
+- Set up staging and production environments.
+- Implement logging, monitoring, and alerting.
+
+## 7. Documentation & Developer Experience
+- Maintain updated docs on setup, contribution guidelines, and architecture.
+- Provide code examples and tutorial videos.
+- Establish community support channels.
+
+## 8. Release Management
+- Adopt semantic versioning and changelog generation.
+- Automate release pipelines with CI/CD.
+- Gather user feedback and iterate regularly.
+
+This document will evolve as the project grows and tasks are completed.


### PR DESCRIPTION
## Summary
- elaborate repository tooling roadmap with monorepo layout, package management, linting, and CI steps

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(fails: no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_689a0b93b8248332850f9f32b2a334ab